### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: monorepo-ci
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [develop, staging, main]


### PR DESCRIPTION
Potential fix for [https://github.com/sonimanish0604/aegissolutionsSaaS/security/code-scanning/2](https://github.com/sonimanish0604/aegissolutionsSaaS/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block at the root of the workflow (above `jobs:`) in `.github/workflows/ci.yml`. This will restrict the permissions of the GITHUB_TOKEN, reducing the risk of privilege misuse. Since the workflow only needs to `read` repository contents (to fetch code for linting/testing), set `contents: read`. If, in the future, another job is added that needs more permissions, you can grant them specifically at the job-level.

Make the following change:
- Insert a `permissions:` block directly after the workflow `name:` and before (or after) the `on:` block, as shown in the "Correct Usage" example from the background.

No additional imports or complex modifications are required—just an addition of the YAML key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
