### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/onboarding-ci.yml
+++ b/.github/workflows/onboarding-ci.yml
@@ -1,5 +1,7 @@
 # .github/workflows/onboarding-ci.yml
 name: onboarding-ci
+permissions:
+  contents: read
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/sonimanish0604/aegissolutionsSaaS/security/code-scanning/1](https://github.com/sonimanish0604/aegissolutionsSaaS/security/code-scanning/1)

To fix this issue, we need to set a `permissions` block in the workflow YAML file. The minimal, recommended setting is `contents: read`, which allows jobs to read repository content (needed by actions/checkout and similar), but not modify it. Since none of the described steps require write permission, we do not need to allow anything further. The best-practice location for this block is at the workflow root level (just after the `name:` line; before or after `on:`), which ensures all jobs inherit these settings unless overridden. Only `.github/workflows/onboarding-ci.yml` needs this edit, and no methods/imports/definitions outside the workflow YAML are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
